### PR TITLE
Update cmd to allow args

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class CFLint(Linter):
     """Provides an interface to CFLint."""
 
     syntax = ('coldfusioncfc', 'html+cfml')
-    cmd = 'cflint -q -text -file'
+    cmd = 'cflint -file @ -q -text'
     version_args = '-version'
     version_re = r'\b(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.1.8'


### PR DESCRIPTION
Change the cmd string so that the "args" argument can be used in linter settings.  The way it was any args would be inserted between the '-file' and the filename which broke the '-file' argument. 

For this config,
"cflint": {
   "@disable": false,
   "args": ['-configfile c:\cflintrc.xml'],
   "excludes": []
}

The results are:
old: cflint -q -text -file -configfile c:\cflintrc.xml index.cfm
new: cflint -file index.cfm -q -text -configfile c:\cflintrc.xml