### PR TITLE
Update for SL4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,8 +16,7 @@ class CFLint(Linter):
     """Provides an interface to CFLint."""
 
     syntax = ('coldfusioncfc', 'html+cfml', 'cfml')
-    executable = 'java'
-    cmd = None
+    cmd = ['java', '${args}', '-file', '@', '-q', '-text']
     regex = r'''(?xi)
         # Severity
         ^\s*Severity:(?:(?P<warning>(WARNING|CAUTION|INFO|COSMETIC))|(?P<error>(FATAL|CRITICAL|ERROR)))\s*$\r?\n
@@ -48,37 +47,6 @@ class CFLint(Linter):
     word_re = r'^<?(#?[-\w]+#?)'
     tempfile_suffix = '-'
     defaults = {
-        'jar_file': '',
-        'config_file_name': '.cflintrc',
-        'aux_config_dirs': []
+        '-jar': '',
+        '-configfile': ''
     }
-
-    def __init__(self, view, syntax):
-        """Override init to dynamically set config_file."""
-
-        Linter.__init__(self, view, syntax)
-
-        settings = self.get_view_settings()
-        config_file_name = settings.get('config_file_name')
-        aux_config_dirs = settings.get('aux_config_dirs')
-        config_file_tuple = ('-configfile', config_file_name)
-
-        for conf in aux_config_dirs:
-            config_file_tuple += (conf,)
-
-        self.config_file = config_file_tuple
-
-    def cmd(self):
-        """Return the command line to execute."""
-
-        jar_file = self.get_jarfile_path()
-
-        return [self.executable_path, '-jar', jar_file, '-file', '@', '-q', '-text']
-
-    def get_jarfile_path(self):
-        """Return the absolute path to the CFLint jar file."""
-
-        settings = self.get_view_settings()
-        jar_file = settings.get('jar_file')
-
-        return jar_file


### PR DESCRIPTION
This is an example how this could work in SL4.

`'-jar'` if you prefix a default with e.g. `-` it will be recognized as cli argument and injected at `${args}`. Likewise for `-configfile`. Esp. for the configfile the user could point to `${folder}/.myconfig.xml` or `~/.myotherconfig.xml`. `$folder` will expand to the project folder.