### PR TITLE
More fixes, replace deprecated features

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -9,14 +9,17 @@
 #
 
 """This module exports the CFLint plugin class."""
-from SublimeLinter.lint import Linter, util
+import logging
+from SublimeLinter.lint import Linter
+
+
+logger = logging.getLogger('SublimeLinter.plugin.eslint')
 
 
 class CFLint(Linter):
     """Provides an interface to CFLint."""
 
     syntax = ('coldfusioncfc', 'html+cfml', 'cfml')
-    cmd = ['java', '${args}', '-file', '@', '-q', '-text']
     regex = r'''(?xi)
         # Severity
         ^\s*Severity:(?:(?P<warning>(WARNING|CAUTION|INFO|COSMETIC))|(?P<error>(FATAL|CRITICAL|ERROR)))\s*$\r?\n
@@ -43,10 +46,45 @@ class CFLint(Linter):
         ^.*$\r?\n
     '''
     multiline = True
-    error_stream = util.STREAM_STDOUT
     word_re = r'^<?(#?[-\w]+#?)'
-    tempfile_suffix = '-'
     defaults = {
-        '-jar': '',
+        'jar': '',
         '-configfile': ''
     }
+
+    def cmd(self):
+        jar = self.settings.get('jar')
+        if not jar:
+            logger.error(jar_file_missing_error_message)
+            return None
+
+        return [
+            'java', '-jar', jar,
+            '-stdin', '${file}',
+            '-stdout',
+            '-text',
+            '-q',
+            '${args}'
+        ]
+
+
+jar_file_missing_error_message = """
+You MUST set the `jar` setting. It should point to your 'CFLint-*-all.jar'.
+The absolute path is usually necessary unless this file is right in your working
+dir.
+
+E.g. for the global SublimeLinter settings:
+
+    "linters": {
+        "cflint": {
+            "jar": "path/to/CFLint-1.4.0-all.jar"
+        }
+    }
+
+In project settings, you would use something like this:
+
+    "settings": {
+        "SublimeLinter.linters.cflint.jar": "path/to/CFLint-1.4.0-all.jar"
+    }
+
+"""

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,6 @@ logger = logging.getLogger('SublimeLinter.plugin.eslint')
 class CFLint(Linter):
     """Provides an interface to CFLint."""
 
-    syntax = ('coldfusioncfc', 'html+cfml', 'cfml')
     regex = r'''(?xi)
         # Severity
         ^\s*Severity:(?:(?P<warning>(WARNING|CAUTION|INFO|COSMETIC))|(?P<error>(FATAL|CRITICAL|ERROR)))\s*$\r?\n
@@ -48,6 +47,7 @@ class CFLint(Linter):
     multiline = True
     word_re = r'^<?(#?[-\w]+#?)'
     defaults = {
+        'selector': 'embedding.cfml, source.cfml, source.cfscript, text.html.cfm',
         'jar': '',
         '-configfile': ''
     }


### PR DESCRIPTION
The current version actually does not work with recent versions of CFLint. Simply bc
just by setting `-text` the output will be written to a file and not to stdout. 

We thus must use `-stdout` flag. But then we can also use `-stdin` and get background linting.

Switch to stdin/-out processing  
- Switch to -stdin and -stdout which generally enables background linting.
- Since setting `jar` is mandatory, fail early if not set and show nice
  error message.
- Since 'jar' is an argument to the java binary do not handle it via
  `$args`. $args should only contain arguments to the cflinter.


Use `selector` instead of `syntax`  
`syntax` has been deprecated in favor of `selector`. Note that the latter
is also configurable by the user now.